### PR TITLE
fix(StaveBox): fixed column traversal when traversing up at top of column

### DIFF
--- a/src/component/staveBox.js
+++ b/src/component/staveBox.js
@@ -149,7 +149,7 @@ export class StaveBox {
 
                                 if (nextcell === undefined){
                                     if (altHeld) {nextcell =    this.cellArray[index + (this.gridWidth * (this.localTuning.length - 1))]}
-                                    else {nextcell =            this.cellArray[index + (this.gridWidth * (this.localTuning.length - 1)) - 1]}
+                                    else {nextcell =            this.cellArray[index + (this.gridWidth * (this.localTuning.length - 1)) + 1]}
                                 }
 
                                 if (nextcell === undefined) { return; }


### PR DESCRIPTION
Fixing unintended interaction from 364ff1315abaeabe55fea5e8c08b86c957d4d780 

Pressing up at the top of stave grid column should go to the right instead of left