### PR TITLE
feat: better element dragging

### DIFF
--- a/src/component/contextMenu.js
+++ b/src/component/contextMenu.js
@@ -1,7 +1,7 @@
 import { TransientInput } from "@/lib/transientInput.js";
 
 export class ContextMenu {
-    constructor(parentObject, workspaceContext) {
+    constructor(parentObject, workspace) {
         const parentContainer = parentObject.getRootContainer();
         const contextMenu = document.createElement('div');
         contextMenu.classList.add('contextMenu');
@@ -48,18 +48,22 @@ export class ContextMenu {
 
         const elementDragging = (event) => {
             const mouseY = event.clientY;
+            const elementRect = parentContainer.getBoundingClientRect();
             let distanceY = mouseY - elementCenterY;
             parentContainer.style.transform = `translateY(${distanceY + yOffset}px) scale(102%)`
 
 
             //dragging up
             if (previousElement){
-                if (mouseY < (previousElementRect.top + (previousElementRect.height / 2))){
-                    yOffset += previousElementRect.height + parseInt(window.getComputedStyle(parentContainer).paddingBottom);
+                if (elementRect.top < (previousElementRect.top + (previousElementRect.height / 2))){
+                    yOffset += previousElementRect.height + (workspace.emSize.height);
                     parentContainer.style.transform = `translateY(${distanceY + yOffset}px) scale(102%)`;
 
+                    if (previousElement){previousElement.classList.toggle('glowBelow', false)};
+                    if (nextElement){nextElement.classList.toggle('glowAbove', false)};
+
                     parentObject.decPositionInWorkspace();
-                    workspaceContext.insertBefore(parentContainer, previousElement);
+                    workspace.el.insertBefore(parentContainer, previousElement);
 
                     //because inserting copies the object, css logic for displaying :active doesnt work
                     //so here I force it with a class and remove the class on mouseup
@@ -67,16 +71,26 @@ export class ContextMenu {
 
                     previousElement = parentContainer.previousElementSibling;
                     nextElement = parentContainer.nextElementSibling;
-                    if (previousElement){previousElementRect = previousElement.getBoundingClientRect()};
-                    if (nextElement){nextElementRect = nextElement.getBoundingClientRect()};
+
+                    if (previousElement){
+                        previousElementRect = previousElement.getBoundingClientRect();
+                        previousElement.classList.toggle('glowBelow', true);
+                    };
+                    if (nextElement){
+                        nextElementRect = nextElement.getBoundingClientRect();
+                        nextElement.classList.toggle('glowAbove', true);
+                    };
                 }
             }
 
             //dragging down
             if (nextElement){
-                if (mouseY > (nextElementRect.bottom - (nextElementRect.height/2))){
-                    yOffset -= nextElementRect.height + parseInt(window.getComputedStyle(parentContainer).paddingBottom);
-                    parentContainer.style.transform = `translateY(${distanceY + yOffset}px) scale(102%)`
+                if (elementRect.bottom > (nextElementRect.bottom - (nextElementRect.height/2))){
+                    yOffset -= nextElementRect.height + (workspace.emSize.height);
+                    parentContainer.style.transform = `translateY(${distanceY + yOffset}px) scale(102%)`;
+
+                    if (previousElement){previousElement.classList.toggle('glowBelow', false)};
+                    if (nextElement){nextElement.classList.toggle('glowAbove', false)};
 
                     parentObject.incPositionInWorkspace();
                     nextElement.insertAdjacentElement('afterend', parentContainer);
@@ -86,8 +100,15 @@ export class ContextMenu {
 
                     previousElement = parentContainer.previousElementSibling;
                     nextElement = parentContainer.nextElementSibling;
-                    if (previousElement){previousElementRect = previousElement.getBoundingClientRect()};
-                    if (nextElement){nextElementRect = nextElement.getBoundingClientRect()};
+
+                    if (previousElement){
+                        previousElementRect = previousElement.getBoundingClientRect();
+                        previousElement.classList.toggle('glowBelow', true);
+                    };
+                    if (nextElement){
+                        nextElementRect = nextElement.getBoundingClientRect();
+                        nextElement.classList.toggle('glowAbove', true);
+                    };
                 }
             }
 
@@ -123,6 +144,10 @@ export class ContextMenu {
 
                 previousElement = parentContainer.previousElementSibling;
                 nextElement = parentContainer.nextElementSibling;
+
+                if (previousElement){previousElement.classList.toggle('glowBelow', true)};
+                if (nextElement){nextElement.classList.toggle('glowAbove', true)};
+
                 if (previousElement){previousElementRect = previousElement.getBoundingClientRect()};
                 if (nextElement){nextElementRect = nextElement.getBoundingClientRect()};
 
@@ -136,6 +161,13 @@ export class ContextMenu {
                     yOffset = 0;
                     parentContainer.classList.remove('dragged');
                     if (parentContainer.contains(event.target) && parentContainer.classList.contains('stave')) { parentObject.openHoverMenu(); }
+
+                    previousElement = parentContainer.previousElementSibling;
+                    nextElement = parentContainer.nextElementSibling;
+
+                    if (previousElement){previousElement.classList.toggle('glowBelow', false)};
+                    if (nextElement){nextElement.classList.toggle('glowAbove', false)};
+
                     document.removeEventListener('mousemove', elementDragging);
                 })
 

--- a/src/component/staveBox.js
+++ b/src/component/staveBox.js
@@ -40,7 +40,7 @@ export class StaveBox {
         this.staveContainer.classList.add('prototypeContainer','stave');
         this.parentWorkspace.el.appendChild(this.staveContainer);
 
-        this.contextMenu = new ContextMenu(this, this.parentWorkspace.el);
+        this.contextMenu = new ContextMenu(this, this.parentWorkspace);
         this.staveContainer.appendChild(this.contextMenu);
 
         this.staveBox = document.createElement('div');

--- a/src/component/textBox.js
+++ b/src/component/textBox.js
@@ -9,7 +9,7 @@ export class TextBox {
         this.textContainer.classList.add('prototypeContainer','text');
         this.parentWorkspace.el.appendChild(this.textContainer);
 
-        const contextMenu = new ContextMenu(this, this.parentWorkspace.el);
+        const contextMenu = new ContextMenu(this, this.parentWorkspace);
         this.textContainer.appendChild(contextMenu);
 
         this.textBox = document.createElement('div');

--- a/src/style.css
+++ b/src/style.css
@@ -208,6 +208,9 @@ body{
     margin: auto;
     margin-top: 1em;
     font-size: 1em;
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
 }
 
 .workspaceContainer:focus{
@@ -248,13 +251,13 @@ body{
     background-color: transparent;
     display: grid;
     border-radius: 1rem;
-    box-shadow: 0 0 5px rgba(0,0,0,0);
+    box-shadow: 0 0 0px rgba(0,0,0,0);
     transition:
         box-shadow 80ms ease-in-out;
     padding: 0.5rem;
     min-height: 1em;
     width: fit-content;
-    margin-bottom: 0.5em;
+    margin: 0em;
     color: #282828;
     transform: scale(100%);
     backdrop-filter: 0;
@@ -285,6 +288,16 @@ body{
 
 .prototypeContainer.dragged:not(.dragHandle) div{
     pointer-events: none;
+}
+
+.prototypeContainer.glowAbove{
+    box-shadow: 0px -4px 6px color-mix(in srgb, var(--color-light-secondary) 90%, transparent);
+    margin-top: 0.5em;
+}
+
+.prototypeContainer.glowBelow{
+    box-shadow: 0px 4px 6px color-mix(in srgb, var(--color-light-secondary) 90%, transparent);
+    margin-bottom: 0.5em;
 }
 
 .prototypeContainer.stave{


### PR DESCRIPTION
fixes #11 

* while dragging, elements now use top and bottom of their rect as opposed to mouse Y position when deciding whether to reposition
* added more visual clarity when dragging, margins on surrounding elements increase and have an offset border-shadow