### PR TITLE
refactor(transient-input): cleaner implementation

### DIFF
--- a/src/component/contextMenu.js
+++ b/src/component/contextMenu.js
@@ -120,8 +120,7 @@ export class ContextMenu {
                 const parentFuncs = parentObject.contextMenuOptions;
 
                 //open expanded context menu on right click
-                const popUpContextMenu = new TransientInput;
-                popUpContextMenu.setPosition(event, null);
+                const popUpContextMenu = new TransientInput(dragButton, {x: event.pageX,y: event.pageY});
                 popUpContextMenu.createAndAddLabel(parentObject.getObjectNameAsString());
                 popUpContextMenu.createAndAddDivisor();
                 //add parent's menu options
@@ -132,7 +131,7 @@ export class ContextMenu {
                         return true;
                     })
                 }
-
+                
                 popUpContextMenu.endTransientInput();
 
 

--- a/src/component/notationLegend.js
+++ b/src/component/notationLegend.js
@@ -136,8 +136,7 @@ class TechniqueEntry{
         this.componentContainer.addEventListener('mousedown', (event) => {
             if (event.button == 2){
                 event.preventDefault()
-                const editEntryMenu = new TransientInput;
-                editEntryMenu.setPosition(event, null);
+                const editEntryMenu = new TransientInput(this.componentContainer, {x: event.pageX,y: event.pageY});
                 editEntryMenu.createAndAddLabel('Notation legend entry');
                 editEntryMenu.createAndAddDivisor();
                 editEntryMenu.createAndAddButton('edit text', ()=>{

--- a/src/component/ribbon.js
+++ b/src/component/ribbon.js
@@ -32,10 +32,8 @@ export function AddStaveBoxButton(_ribbon, workspace){
     staveBoxDropdown.innerHTML = window.electronAPI.getIcon('collapse');
     staveBoxDropdown.title = "StaveBox Options"
     staveBoxDropdown.onclick = function(){
-        const staveBoxOptionsMenu = new TransientInput();
         const buttonRect = staveBoxDropdown.getBoundingClientRect();
-        const cornerPosition = {x: buttonRect.left, y: buttonRect.top};
-        staveBoxOptionsMenu.setPosition(null, cornerPosition);
+        const staveBoxOptionsMenu = new TransientInput(staveBoxDropdown, {x: buttonRect.left, y: buttonRect.top});
         staveBoxOptionsMenu.createAndAddLabel('StaveBox settings');
         staveBoxOptionsMenu.createAndAddDivisor();
         staveBoxOptionsMenu.createAndAddLabel('tuning');

--- a/src/component/staveBox.js
+++ b/src/component/staveBox.js
@@ -347,8 +347,7 @@ export class StaveBox {
         this.drawGrid(this.staveBoxGrid, this.cellArray);
 
         const openTuningMenu = (mouseEvent) => {
-            const popUpContextMenu = new TransientInput;
-            popUpContextMenu.setPosition(mouseEvent, null);
+            const popUpContextMenu = new TransientInput(this.stringLabels, {x: mouseEvent.pageX,y: mouseEvent.pageY});
             popUpContextMenu.createAndAddLabel('Tuning:');
             popUpContextMenu.createAndAddTextInput(this.localTuning.join('/'), (contents) => {
             if (!contents.includes('/')) { return false; };
@@ -434,8 +433,7 @@ export class StaveBox {
                 if (ev.button != 2) { return; }
                 ev.preventDefault();
 
-                const popUpContextMenu = new TransientInput;
-                popUpContextMenu.setPosition(ev, null);
+                const popUpContextMenu = new TransientInput(this.staveArticulationContainer, {x: ev.pageX,y: ev.pageY});
                 popUpContextMenu.createAndAddLabel('Stave Articulation');
                 popUpContextMenu.createAndAddDivisor()
                 popUpContextMenu.createAndAddButton('clear', (ev) => {

--- a/src/lib/transientInput.js
+++ b/src/lib/transientInput.js
@@ -1,20 +1,25 @@
 export class TransientInput {
-    constructor() {
+    constructor(target = document.body, pos = {x: 0, y: 0}) {
         if (document.getElementsByClassName('transientInputContainer').length){
             for (let element of document.getElementsByClassName('transientInputContainer')){
                 element.remove();
             }
         }
+        this.target = target;
         this.transientInputContainer = document.createElement('div');
         this.transientInputContainer.classList.add('transientInputContainer');
         document.body.appendChild(this.transientInputContainer);
 
+        this.transientInputContainer.style.transform = `translate(${this.x}px, ${this.y}px)`;
+
         this.callbackList = [];
 
-        this.x = 0;
-        this.y = 0;
+        this.x = pos.x;
+        this.y = pos.y;
+
 
         const clickHandler = (_event) => {
+            _event.preventDefault();
             if (!this.transientInputContainer.contains(_event.target)){
                 this.transientInputContainer.remove();
                 document.removeEventListener('mousedown', clickHandler)}
@@ -24,19 +29,6 @@ export class TransientInput {
             document.addEventListener('mousedown', clickHandler)
         }, 0);
 
-
-    }
-
-    setPosition(mouseEvent = null, positionOverride = null){
-        if (mouseEvent){
-            this.x = mouseEvent.pageX;
-            this.y = mouseEvent.pageY;
-        } else if (positionOverride) {
-            this.x = positionOverride.x;
-            this.y = positionOverride.y;
-        }
-
-        this.transientInputContainer.style.transform = `translate(${this.x}px, ${this.y}px)`;
 
     }
 
@@ -126,12 +118,19 @@ export class TransientInput {
         transientInputEnd.classList.add('transientItem', 'end');
         this.transientInputContainer.appendChild(transientInputEnd);
         const rect = this.transientInputContainer.getBoundingClientRect();
-        if (rect.top > 0 && rect.left > 0 && rect.bottom < window.innerHeight && rect.right < window.innerWidth){
-
+        //10px margin
+        const margin = 10;
+        const top = (this.y) < (0 + margin);
+        const left = (this.x) < (0 + margin);
+        const right = (this.x + rect.width) > (window.innerWidth - margin);
+        const bottom = (this.y + rect.height) > (window.innerHeight - margin);
+        if (bottom){
+            this.transientInputContainer.style.transform = `translate(${this.x}px, ${this.y - rect.height}px)`;
         } else {
-            const yOffset = rect.height;
-            this.transientInputContainer.style.transform = `translate(${this.x}px, ${this.y - yOffset}px)`;
+            this.transientInputContainer.style.transform = `translate(${this.x}px, ${this.y}px)`;
         };
+
+        this.target.focus({focusVisible: true});
     }
 
 }


### PR DESCRIPTION
Transient inputs now require two parameters when instantiated:
* target (usually the event.target which caused it)
* object with x, y position

This means there is no use for the setPosition() method anymore. 